### PR TITLE
calculateBusRouteTime created

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "mapbox-gl": "^2.9.2",
+        "moment": "^2.29.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -12300,6 +12301,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "mapbox-gl": "^2.9.2",
+    "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/my-app/src/Map.js
+++ b/my-app/src/Map.js
@@ -9,6 +9,7 @@ mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_KEY
 // takes in a route ID, starting bus stop ID, and ending bus stop ID, and calculates the time to travel between them
 // assumes the next bus available is taken
 // Uses the catbus.ridesystems.net API, with ids taken from there
+// Returns time between the two stops in milliseconds
 async function calculateBusRouteTime(routeID, startingStopID, endingStopID){
         const time = await fetch('https://catbus.ridesystems.net/Services/JSONPRelay.svc/GetRouteStopArrivals').then(response => response.json())
         .then(data => {


### PR DESCRIPTION
# Description

This PR creates a method to calculate times between two bus stops. Uses the [catbus.ridesystems.net](https://catbus.ridesystems.net/) API. We may need to make changes to make this compatible, but the my.Clemson API doesn't have the needed functionality. The travel time between the routes is returned in milliseconds. The function will be used for CN-5.

Fixes # [CN-17](https://jpt4.atlassian.net/browse/CN-17)

# How Has This Been Tested?

- The method is called in Map.js to test it
- The resulting time is printed in the console
- You can change the IDs used to test it more, look at https://catbus.ridesystems.net/Services/JSONPRelay.svc/GetRouteStopArrivals to find IDs

# Checklist:

- [x] Have you merged main into this branch and resolved any conflicts?
- [x] Have you updated any necessary documentation?
- [x] Have you successfully run tests with your changes locally?



[CN-17]: https://jpt4.atlassian.net/browse/CN-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ