### PR TITLE
CN-18: Select optimal route

### DIFF
--- a/my-app/ridesystems-endpoints.md
+++ b/my-app/ridesystems-endpoints.md
@@ -1,0 +1,20 @@
+Get all routes. Also includes stop info
+`catbus.ridesystems.net/Services/JSONPRelay.svc/GetRoutesForMap`
+
+Get all routes, with schedule
+`catbus.ridesystems.net/Services/JSONPRelay.svc/GetRoutesForMapWithSchedule`
+
+Get all routes, with schedule, and with encoded lines storing the path of the route
+`catbus.ridesystems.net/Services/JSONPRelay.svc/GetRoutesForMapWithScheduleWithEncodedLine`
+
+Get arrivals for each stop  
+`catbus.ridesystems.net/Services/JSONPRelay.svc/GetRouteStopArrivals`
+
+Get bus locations
+`catbus.ridesystems.net/Services/JSONPRelay.svc/GetMapVehiclePoints`
+
+Get capacities  
+`GetVehicleCapacities`
+
+Get stop arrival times
+`GetStopArrivalTimes?stopIds={stop_id}`

--- a/my-app/src/Instructions.js
+++ b/my-app/src/Instructions.js
@@ -1,0 +1,16 @@
+import React, { useRef, useEffect, useState } from "react";
+
+export default function Instructions(props) {
+  // console.log(props);
+  const steps = props.props;
+  console.log(steps);
+  const listItems = steps.map((step, i) => (
+    <li key={i}>{step?.maneuver?.instruction}</li>
+  ));
+
+  return (
+    <div id="instructions">
+      <ul>{listItems}</ul>
+    </div>
+  );
+}

--- a/my-app/src/Instructions.js
+++ b/my-app/src/Instructions.js
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useState } from "react";
 export default function Instructions(props) {
   // console.log(props);
   const steps = props.props;
-  console.log(steps);
+  // console.log(steps);
   const listItems = steps.map((step, i) => (
     <li key={i}>{step?.maneuver?.instruction}</li>
   ));

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -32,3 +32,16 @@ div.Map {
 .map-container {
   height: 90%;
 }
+
+#instructions {
+  position: absolute;
+  margin: 20px;
+  width: 25%;
+  top: 10%;
+  bottom: 50%;
+  padding: 20px;
+  background-color: #fff;
+  overflow-y: scroll;
+  font-family: sans-serif;
+  text-align: left;
+}


### PR DESCRIPTION
# Description

This PR implements a function to select the fastest possible route, taking into consideration the starting and ending points. This PR also refactors OnCalculateHandler for readability. Routes are now fetched from the ridesystems API, which has the side effect of preventing the use of on campus busses. We should fix this later.

NOTE: A known issue with drawNavRoute ([CN-26](https://jpt4.atlassian.net/browse/CN-26)) causes this to break for some routes. I would suggest we go ahead and merge anyway, to enable progress on other tickets.

Fixes # [CN-18](https://jpt4.atlassian.net/browse/CN-18)

# How Has This Been Tested?

Enter a starting address and ending address, then verify the stops selected seem reasonable.  

Some routes I tested:
- 97 Calhoun Street to 821 McMillan Road
- 758 Queens Park Loop to 821 McMillan Road
- 821 McMillan Road to 97 Calhoun Street

# Checklist:

- [x] Have you merged main into this branch and resolved any conflicts?
- [x] Have you updated any necessary documentation?
- [x] Have you successfully run tests with your changes locally?



[CN-26]: https://jpt4.atlassian.net/browse/CN-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-18]: https://jpt4.atlassian.net/browse/CN-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ